### PR TITLE
Add hostname to reversed sourcemaps

### DIFF
--- a/internal/core/asset-service/file-service.go
+++ b/internal/core/asset-service/file-service.go
@@ -23,7 +23,7 @@ type SaveFileRequest struct {
 	// because in reality this will be a URL
 	PathURL string
 	// Content is the file content
-	Content string
+	Content *string
 }
 
 type FileService interface {
@@ -126,7 +126,7 @@ func (s *fileServiceImpl) FileExists(pathURL string, subfolder string) (bool, er
 	return false, errutil.Wrap(err, "failed to check if file exists")
 }
 
-func (s *fileServiceImpl) SimpleSave(filePath string, content string) (string, error) {
+func (s *fileServiceImpl) SimpleSave(filePath string, content *string) (string, error) {
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return filePath, errutil.Wrap(err, "failed to create directory")
@@ -134,7 +134,7 @@ func (s *fileServiceImpl) SimpleSave(filePath string, content string) (string, e
 
 	s.log.Debug("saving to file", "filepath", filePath, "dir", dir)
 
-	err := os.WriteFile(filePath, []byte(content), 0644)
+	err := os.WriteFile(filePath, []byte(*content), 0644)
 	if err != nil {
 		return filePath, errutil.Wrap(err, "failed to create file and write content")
 	}

--- a/internal/core/common/util.go
+++ b/internal/core/common/util.go
@@ -84,14 +84,14 @@ const (
 	ContentTypeJS   = "JS"
 )
 
-func DetectContentType(content string) ContentType {
-	mimeType := http.DetectContentType([]byte(content))
+func DetectContentType(content *string) ContentType {
+	mimeType := http.DetectContentType([]byte(*content))
 
 	if strings.Contains(mimeType, "html") {
 		return ContentTypeHTML
 	}
 
-	if strings.Contains(mimeType, "text/plain") && isLikelyJavaScript(content) {
+	if strings.Contains(mimeType, "text/plain") && isLikelyJavaScript(*content) {
 		return ContentTypeJS
 	}
 
@@ -230,4 +230,8 @@ func UpdateProjectName(projectName string) error {
 	}
 
 	return nil
+}
+
+func ToPtr[T any](v T) *T {
+	return &v
 }

--- a/internal/modules/html-ingestion/html-ingestion.go
+++ b/internal/modules/html-ingestion/html-ingestion.go
@@ -59,8 +59,8 @@ func (m *htmlIngestionModule) subscribeIngestionRequestTopic() error {
 	return nil
 }
 
-func (m *htmlIngestionModule) handleIngestionRequest(req ingestion.IngestionRequest) error {
-	err := m.validateIngestionRequest(&req)
+func (m *htmlIngestionModule) handleIngestionRequest(req *ingestion.IngestionRequest) error {
+	err := m.validateIngestionRequest(req)
 	if err != nil {
 		m.sdk.Logger.Debug("request is not valid", "err", err, "req_url", req.Request.URL)
 		return nil // request is not valid, skip
@@ -75,9 +75,9 @@ func (m *htmlIngestionModule) handleIngestionRequest(req ingestion.IngestionRequ
 
 	m.sdk.Logger.Debug("htmlingestion - saving html asset", "html_path", htmlPath)
 
-	m.sdk.AssetService.AsyncSaveAsset(m.sdk.Ctx, assetservice.Asset{
+	m.sdk.AssetService.AsyncSaveAsset(m.sdk.Ctx, &assetservice.Asset{
 		URL:            htmlPath,
-		Content:        req.Response.Body,
+		Content:        &req.Response.Body,
 		ContentType:    common.ContentTypeHTML,
 		Project:        m.sdk.Options.ProjectName,
 		RequestHeaders: req.Request.Headers,
@@ -94,9 +94,9 @@ func (m *htmlIngestionModule) handleIngestionRequest(req ingestion.IngestionRequ
 			return errutil.Wrap(err, "failed to join inline js path")
 		}
 
-		m.sdk.AssetService.AsyncSaveAsset(m.sdk.Ctx, assetservice.Asset{
+		m.sdk.AssetService.AsyncSaveAsset(m.sdk.Ctx, &assetservice.Asset{
 			URL:            inlinePath,
-			Content:        content,
+			Content:        &content,
 			ContentType:    common.ContentTypeJS,
 			Project:        m.sdk.Options.ProjectName,
 			RequestHeaders: req.Request.Headers,
@@ -128,7 +128,7 @@ func (m *htmlIngestionModule) validateIngestionRequest(req *ingestion.IngestionR
 	contentTypeHeader := m.getContentType(*req)
 	if !strings.Contains(contentTypeHeader, "html") {
 		// try to detect from the response body
-		contentType := common.DetectContentType(req.Response.Body)
+		contentType := common.DetectContentType(&req.Response.Body)
 
 		m.sdk.Logger.Debug("htmlingestion - detected content from response body", "url", req.Request.URL, "content-type", contentType, "content-type-header", contentTypeHeader)
 

--- a/internal/modules/ingestion/events.go
+++ b/internal/modules/ingestion/events.go
@@ -5,5 +5,5 @@ const (
 )
 
 type EventIngestionRequestReceived struct {
-	IngestionRequest IngestionRequest
+	IngestionRequest *IngestionRequest
 }

--- a/internal/modules/ingestion/ingestion.go
+++ b/internal/modules/ingestion/ingestion.go
@@ -83,7 +83,7 @@ func (m *ingestionModule) handleIngestionCaidoIngestionEndpoint(w http.ResponseW
 func (m *ingestionModule) handleIngestionRequest(req IngestionRequest) {
 	m.sdk.InMemoryEventBus.Publish(TopicIngestionRequestReceived, eventbus.Message{
 		Data: EventIngestionRequestReceived{
-			IngestionRequest: req,
+			IngestionRequest: &req,
 		},
 	})
 }

--- a/internal/modules/sourcemaps/sourcemaps.go
+++ b/internal/modules/sourcemaps/sourcemaps.go
@@ -149,7 +149,7 @@ func (s *sourceMapsModule) sourceMapDiscover(ctx context.Context, asset assetser
 
 	filePath, err := s.sdk.FileService.SaveInSubfolder(ctx, SourceMapsFolder, assetservice.SaveFileRequest{
 		PathURL: urlToSave,
-		Content: sourceMap.OriginalContent,
+		Content: &sourceMap.OriginalContent,
 	})
 	if err != nil {
 		return dbeventbus.NewRetriableError(errors.Wrapf(err, "failed to save source map for asset %s", asset.URL))
@@ -179,6 +179,7 @@ func (s *sourceMapsModule) sourceMapDiscover(ctx context.Context, asset assetser
 		common.GetWorkingDirectory(s.sdk.Options.ProjectName),
 		SourceMapsFolder,
 		SourceMapsReversed,
+		sourceMap.URL.Host,
 	}
 
 	// reverseSourceMapsDir = append(reverseSourceMapsDir, assetPath...)


### PR DESCRIPTION
- Adds a prefix hostname to the reversed sourcemaps to reduce the likelyhood of clases
- Uses pointers for content to reduce memory usage
- Avoids creating a large number of chunk discovery go routines to reduce memory usage